### PR TITLE
due_on in task is not always a string

### DIFF
--- a/test/assert.js
+++ b/test/assert.js
@@ -30,8 +30,8 @@ assert.isTask = function (task) {
   assert.isString(task.notes);
   assert.isBoolean(task.completed);
   assert.isString(task.assignee_status);
-  assert.isString(task.due_on);
   assert.isArray(task.projects);
   assert.isObject(task.workspace);
   assert.isArray(task.followers);
+  !task.due_on || assert.isString(task.due_on)
 };


### PR DESCRIPTION
This item is returned as `null` by asana if not set for the task, which fails a test that's expecting it to be a string (ISO 8601 date):

```
  When using an instance of asana.Client the tasks.get() method
    ✗ should respond with a valid task 
        » expected null to be a String // assert.js:33
```

This makes `assert.isString(task.due_on)` only run if task.due_on is not null.
