### PR TITLE
Use nodes build in status codes for errors rather than your own list

### DIFF
--- a/lib/asana-api/client.js
+++ b/lib/asana-api/client.js
@@ -109,21 +109,22 @@ Client.prototype.request = function (options, callback) {
     var statusCode = response.statusCode.toString(),
         result;
 
+    if (Object.keys(self.successCodes).indexOf(statusCode) === -1) {
+      return callback(errs.create({
+        message: 'Asana Error (' + statusCode + '): ' + http.STATUS_CODES[statusCode],
+        result: null,
+        status: statusCode
+      }));
+    }
+
     try {
       result = JSON.parse(body);
     }
     catch (error) {
       return callback(error);
-      // Ignore Errors
     }
 
-    if (Object.keys(self.successCodes).indexOf(statusCode) === -1) {
-      return callback(errs.create({
-        message: 'Asana Error (' + statusCode + '): ' + http.STATUS_CODES[statusCode],
-        result: result,
-        status: statusCode
-      }));
-    }
+
 
     callback(null, result.data);
   });

--- a/lib/asana-api/client.js
+++ b/lib/asana-api/client.js
@@ -10,6 +10,7 @@ var events = require('events'),
     errs = require('errs'),
     utile = require('utile'),
     request = require('request'),
+    http = require('http'),
     base64 = utile.base64;
 
 var resources = {
@@ -32,14 +33,14 @@ var Client = exports.Client = function (options) {
   events.EventEmitter.call(this);
 
   this.url = 'https://app.asana.com/api/1.0';
-  
+
   //
   // If a token is provided, use oauth and accessToken instead of API key
   //
   if (options.token) {
     this.token = options.token;
     this.auth = 'Bearer ' + options.token;
-  } else { 
+  } else {
     //
     // revert to API Key method
     //
@@ -59,15 +60,6 @@ var Client = exports.Client = function (options) {
 //
 utile.inherits(Client, events.EventEmitter);
 
-// Failure HTTP Response codes based
-// off of `/lib/conservatory/provisioner/service.js`
-Client.prototype.failCodes = {
-  400: 'Bad Request',
-  401: 'Not authorized',
-  403: 'Forbidden',
-  404: 'Item not found',
-  500: 'Internal Server Error'
-};
 
 // Success HTTP Response codes based
 // off of `/lib/conservatory/provisioner/service.js`
@@ -115,19 +107,19 @@ Client.prototype.request = function (options, callback) {
     }
 
     var statusCode = response.statusCode.toString(),
-        result,
-        error;
+        result;
 
     try {
       result = JSON.parse(body);
     }
-    catch (ex) {
+    catch (error) {
+      return callback(error);
       // Ignore Errors
     }
 
-    if (Object.keys(self.failCodes).indexOf(statusCode) !== -1) {
+    if (Object.keys(self.successCodes).indexOf(statusCode) === -1) {
       return callback(errs.create({
-        message: 'Asana Error (' + statusCode + '): ' + self.failCodes[statusCode],
+        message: 'Asana Error (' + statusCode + '): ' + http.STATUS_CODES[statusCode],
         result: result,
         status: statusCode
       }));

--- a/package.json
+++ b/package.json
@@ -1,13 +1,17 @@
 {
   "name": "asana-api",
   "description": "A nodejs client implementation for Asana API",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "http://github.com/indexzero/node-asana-api.git" 
+    "url": "http://github.com/indexzero/node-asana-api.git"
   },
-  "keywords": ["asana", "api", "project management"],
+  "keywords": [
+    "asana",
+    "api",
+    "project management"
+  ],
   "dependencies": {
     "errs": "0.2.x",
     "request": "2.21.x",
@@ -17,6 +21,10 @@
     "vows": "0.7.x"
   },
   "main": "./lib/asana-api",
-  "scripts": { "test": "vows test/*-test.js --spec" },
-  "engines": { "node": ">= 0.6.0" }
+  "scripts": {
+    "test": "vows test/*-test.js --spec"
+  },
+  "engines": {
+    "node": ">= 0.6.0"
+  }
 }


### PR DESCRIPTION
By using http.STATUS_CODES[statusCode] we get more status codes.

If the parsing fails the error is now returned to the callback.

Please not that I could not get the tests to run due to lacking config.