### PR TITLE
Extend request to attempt refresh of OAuth token if expired

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A node.js client implementation for Asana API.
 
 ## Usage
 
+### Create the client with an API key
+
 ``` js
   var asana = require('asana-api');
 
@@ -19,7 +21,7 @@ A node.js client implementation for Asana API.
   });
 ```
 
-## Alternatively create the client with an OAuth token
+### Alternatively, create the client with an OAuth access token
 
 ``` js
   var asana = require('asana-api');
@@ -35,6 +37,31 @@ A node.js client implementation for Asana API.
     console.dir(users);
   });
 ```
+
+**Or go even further and supply enough information for OAuth to refresh the access token**
+
+``` js
+  var asana = require('asana-api');
+  
+  var client = asana.createClient({
+    oauth: {
+      "accessToken" : "your-oauth-token",
+      "refreshToken" : "your-oauth-refresh-token",
+      "clientId" : "your-client-id",
+      "clientSecret" : "your-client-secret",
+      "redirectUrl" : "your-redirect-url-to-store-new-token"
+    }
+  });
+  
+  client.users.list(function (err, users) {
+    //
+    // List all users for this Asana account.
+    //
+    console.dir(users);
+  });
+```
+
+
 
 ## API Coverage
 

--- a/lib/asana-api/client.js
+++ b/lib/asana-api/client.js
@@ -32,20 +32,31 @@ var Client = exports.Client = function (options) {
   events.EventEmitter.call(this);
 
   this.url = 'https://app.asana.com/api/1.0';
+  this.oauthUrl = 'https://app.asana.com/-/oauth_token';
   
   //
-  // If a token is provided, use oauth and accessToken instead of API key
+  // For backwards compatability, convert the options.token to options.oauth.accessToken
   //
-  if (options.token) {
-    this.token = options.token;
-    this.auth = 'Bearer ' + options.token;
-  } else { 
+  if(options.token) {
+    options.oauth = options.oauth || {};
+    options.oauth.accessToken = options.token;
+  }
+
+  //
+  // If oauth is provided, use oauth tokens instead of API key
+  //
+  if (options.oauth) {
+    this.oauth = options.oauth;
+  } else {
     //
     // revert to API Key method
     //
     this.apiKey = options.apiKey;
-    this.auth = 'Basic ' + base64.encode([options.apiKey, ''].join(':'));
   }
+
+  this.auth = function() {
+    return self.oauth ? 'Bearer ' + self.oauth.accessToken : 'Basic ' + base64.encode([self.apiKey, ''].join(':'));
+  };
 
   this.proxy = options.proxy;
 
@@ -90,18 +101,18 @@ Client.prototype.request = function (options, callback) {
   }
 
   options.method  = options.method || 'GET';
-  options.uri     = this.url + options.path;
+  options.uri     = options.uri || this.url + options.path;
   options.proxy   = options.proxy;
   options.headers = options.headers || {};
   options.headers['content-type'] = options.headers['content-type'] || 'application/json';
-  options.headers['authorization'] = options.headers['authorization'] || this.auth;
+  options.headers['authorization'] = options.headers['authorization'] || self.auth();
 
   if (options.query) {
     options.uri += '?' + qs.stringify(options.query);
     delete options.query;
   }
 
-  if (options.body) {
+  if (options.body && typeof(options.body) !== 'string') {
     if (options.headers['content-type'] === 'application/json') {
       options.body = JSON.stringify(options.body);
     } else {
@@ -126,13 +137,62 @@ Client.prototype.request = function (options, callback) {
     }
 
     if (Object.keys(self.failCodes).indexOf(statusCode) !== -1) {
-      return callback(errs.create({
-        message: 'Asana Error (' + statusCode + '): ' + self.failCodes[statusCode],
-        result: result,
-        status: statusCode
-      }));
-    }
 
-    callback(null, result.data);
+      //
+      // The 1st 401 might be an expired token, attempt refresh if we have a token
+      //
+
+      if(statusCode === '401' && self.oauth.refreshToken && !self.refreshAttempted) {
+
+        var opts = {};
+
+        refreshBody = {
+          form: {
+            client_id: self.oauth.clientId,
+            client_secret: self.oauth.clientSecret,
+            redirect_uri: self.oauth.redirectUrl,
+            grant_type: 'refresh_token',
+            refresh_token: self.oauth.refreshToken
+          }
+        };
+
+        request.post(self.oauthUrl, refreshBody, function (err, response, body) {
+          
+          if(response.body && response.body.error) {
+            callback(errs.create({
+              message: 'Asana OAuth Refresh Error (' + response.statusCode.toString() + '): ' + response.body.error_description,
+              status: response.statusCode.toString()
+            }));
+          } else {
+            //
+            // Set the new accessToken, update the headers and try again
+            //
+            self.oauth.accessToken = JSON.parse(response.body)['access_token'];
+            options.headers['authorization'] = self.auth();
+
+            self.request(options, callback);
+          }
+
+        });
+
+        //
+        // Only try it once
+        //
+        self.refreshAttempted = true;
+        
+      } else {
+
+        return callback(errs.create({
+          message: 'Asana Error (' + statusCode + '): ' + self.failCodes[statusCode],
+          result: result,
+          status: statusCode
+        }));
+
+      }
+    } else {
+
+      callback(null, result.data);
+
+    }
   });
 };

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -30,12 +30,53 @@ if (config.apiKey) {
   });
 }
 
-if (config.token) {
+if (config.oauth) {
   clientVows.addBatch({
     "When instantiating a new asana.Client": {
       "with a token": {
         topic: function () {
-          var client = helpers.createClientFromToken();
+          var client;
+
+          try {
+            client = helpers.createClientFromToken();
+          } catch(e) {
+            return this.callback(e);
+          }
+
+          this.callback(null, client);
+        },
+        "a valid client should be returned": function (err, client) {
+          assert.isNull(err);
+          assert.isClient(client);
+        }
+      },
+      "with an OAuth accessToken": {
+        topic: function () {
+          var client;
+          
+          try {
+            client = helpers.createClientFromOAuthAccessToken();
+          } catch (e) {
+            return this.callback(e);
+          }
+
+          this.callback(null, client);
+        },
+        "a valid client should be returned": function (err, client) {
+          assert.isNull(err);
+          assert.isClient(client);
+        }
+      },
+      "with an expired accessToken and OAuth refresh" : {
+        topic: function() {
+          var client;
+
+          try {
+            client = helpers.createClientFromOAuthRefresh();
+          } catch(e) {
+            return this.callback(e);
+          }
+
           this.callback(null, client);
         },
         "a valid client should be returned": function (err, client) {

--- a/test/config.json.example
+++ b/test/config.json.example
@@ -1,6 +1,12 @@
 {
   "apiKey": "YOUR-SECRET-API-KEYZ",
-  "token": "OPTIONAL-ASANA-CONNECT-OAUTH-TOKEN",
+  "oauth": {
+  	"accessToken" : "ASANA-CONNECT-OAUTH-TOKEN-TRUMPS-APIKEY",
+  	"refreshToken" : "OPTIONAL-AUTO-REFRESH-TOKEN-AND-BELOW",
+  	"clientId" : "",
+  	"clientSecret" : "",
+  	"redirectUrl" : ""
+  },
   "workspaces": [],
   "users": ["me"],
   "tasks": [],

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -2,7 +2,7 @@
 var asana = require('../lib/asana-api');
 
 exports.createClient = function () {
-  return exports.createClientFromToken() || exports.createClientFromAPIKey();
+  return exports.createClientFromOAuthRefresh() || exports.createClientFromToken() || exports.createClientFromAPIKey();
 };
 
 exports.createClientFromAPIKey = function () {
@@ -15,9 +15,33 @@ exports.createClientFromAPIKey = function () {
 
 exports.createClientFromToken = function () {
   var config = exports.loadConfig();
-  if (!config.token) return null;
+  if (!config.oauth) return null;
   return asana.createClient({
-    token: config.token
+    token: config.oauth.accessToken
+  });
+};
+
+exports.createClientFromOAuthAccessToken = function () {
+  var config = exports.loadConfig();
+  if (!config.oauth) return null;
+  return asana.createClient({
+    oauth: {
+      accessToken: config.oauth.accessToken
+    }
+  });
+};
+
+exports.createClientFromOAuthRefresh = function () {
+  var config = exports.loadConfig();
+  if (!config.oauth) return null;
+  return asana.createClient({
+    oauth: {
+      accessToken : "old-expired-token",
+      refreshToken : config.oauth.refreshToken,
+      clientId : config.oauth.clientId,
+      clientSecret : config.oauth.clientSecret,
+      redirectUrl : config.oauth.redirectUrl
+    }
   });
 };
 


### PR DESCRIPTION
If the OAuth access token provided has expired, supply additional options to refresh it before continuing with the request. This typically happens when the access token is stored during log on, but then expires before the user logs out. Any attempts to use the API will then end in 401 errors.
